### PR TITLE
fix: make category metadata replacement OS-agnostic

### DIFF
--- a/Adversary Simulation Zettelkasten/04 - Templates/0400 - Gen_Note.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/0400 - Gen_Note.md
@@ -1697,11 +1697,11 @@ function customizeCategoriesMetadata(metadata, categories, categoryType) {
     
     const replacementPatterns = {
         'primary': {
-            pattern: 'primary categories:\n  - Add link(s) [[]] back to related PRIMARY categories',
+            pattern: /primary categories:\r?\n  - Add link\(s\) \[\[\]\] back to related PRIMARY categories/,
             replacement: `primary categories:\n  - ${categories.join('\n  - ')}`
         },
         'secondary': {
-            pattern: 'secondary categories:\n  - Add link(s) [[]] back to related SECONDARY categories',
+            pattern: /secondary categories:\r?\n  - Add link\(s\) \[\[\]\] back to related SECONDARY categories/,
             replacement: `secondary categories:\n  - ${categories.join('\n  - ')}`
         }
     };


### PR DESCRIPTION
- Convert string patterns to regex with \r?\n to handle both Unix and Windows line breaks
- Escape special regex characters in replacement patterns
- Resolves template placeholder replacement failure on Windows systems