### PR TITLE
Chore/admonition block quote migration

### DIFF
--- a/Adversary Simulation Zettelkasten/02 - Secondary Categories/Obsidian.md
+++ b/Adversary Simulation Zettelkasten/02 - Secondary Categories/Obsidian.md
@@ -23,13 +23,22 @@ type: Secondary Category
 * [[Obsidian - Plugins]]
 * [[Obsidian - Custom CSS]]
 
+## Core Features
+
+* [[Obsidian - Callouts]]
+
 ## Plugins
 
-* [[Admonition]]
+### Required
+
 * [[Dataview]]
 * [[Templater]]
 * [[Obsidian Git]]
 * [[Emoji Toolbar]]
+
+### Optional
+
+* [[Admonition]]
 
 ***
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Admonition.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Admonition.md
@@ -18,6 +18,21 @@ Adds admonition block-styled content to Obsidian.md, styled after [Material for 
 
 ![](https://raw.githubusercontent.com/javalent/admonitions/master/publish/gifs/all.gif)
 
+> [!important]
+> As of [Obsidian v0.14.0](https://publish.obsidian.md/hub/01+-+Community/Obsidian+Roundup/2022-03-19+Better+Citations+Workflows+%26+Native+Callout+Boxes), Obsidian natively supports admonitions via [callout boxes](https://help.obsidian.md/callouts). This allows you to create visually distinct blocks with different icons and colors directly in your notes without needing to install the community Admonitions plugin.
+> 
+> ````markdown
+> > [!example]
+> > This is an example callout box.
+> ````
+> 
+> > [!example]
+> > This is an example callout box.
+> 
+> While the older, plugin-based Admonition syntax with code blocks (` ```ad-note `) still functions, the newer Callout syntax is recommended for future compatibility. Admonition is therefore labeled an "optional" plugin for this Zettelkasten vault.
+> 
+> For comprehensive internal documentation on native callouts, see [[Obsidian - Callouts]].
+
 ## Installation
 
 1. Admonition[^1] is a registered Obsidian plugin and can be installed directly from `Settings > Community Plugins > Browse`
@@ -40,12 +55,22 @@ icon: <FontAwesome or RPG Awesome icon name>
 color: <R,G,B>
 Your content here.
 ```
+
+```ad-info
+title: Custom Title
+collapse: close
+icon: hat-wizard
+color: 200,0,200
+My custom content.
+```
 ````
 
 ```ad-info
 title: Custom Title
-collapse: none
-Your content here.
+collapse: close
+icon: hat-wizard
+color: 200,0,200
+My custom content.
 ```
 
 #### Supported Parameters
@@ -74,20 +99,6 @@ Your content here.
 | `example`  | `example`                         | Providing code examples, demonstrations, or sample content.    |
 | `quote`    | `quote`, `cite`                   | Highlighting quotes, citations, or references.                 |
 
-## Callouts
-
-As of [Obsidian v0.14.0](https://publish.obsidian.md/hub/01+-+Community/Obsidian+Roundup/2022-03-19+Better+Citations+Workflows+%26+Native+Callout+Boxes), Obsidian natively supports admonitions via "callout boxes". This allows you to create visually distinct blocks with different icons and colors directly in your notes without needing to install the community Admonitions plugin.
-
-````markdown
-> [!example]
-> This is an example callout box.
-````
-
-> [!example]
-> This is an example callout box.
-
-While the older, plugin-based Admonition syntax with code blocks (` ```ad-note `) still functions, the newer Callout syntax is recommended for future compatibility.
-
 ### Nesting
 
 For block-style admonitions, wrap with matching backtick levels.
@@ -101,12 +112,6 @@ Nested content
 ```
 Parent content
 ````
-
-> [!note] Parent
-> > [!warning] Nested Child
-> > Nested content
-> 
-> Parent content 
 `````
 
 ````ad-note
@@ -118,34 +123,21 @@ Nested content.
 Parent content
 ````
 
-> [!note] Parent
-> > [!warning] Nested Child
-> > Nested content
-> 
-> Parent content 
 ## Constraints
 
-It is not possible to embed a footnote in admonition-styled code blocks or callouts, illustrated below:
+It is not possible to embed a footnote in admonition-styled code blocks, illustrated below:
 
 ````markdown
 ```ad-example
 Attempt to embed a footnote in this codeblock, it won't work[^2].
 However, embedded hyperlinks do appear to work, like [this one](https://google.com/example).
 ```
-
-> [!example]
-> Attempt to embed a footnote in this callout, it won't work[^2].
-> However, embedded hyperlinks do appear to work, like [this one](https://google.com/example).
 ````
 
 ```ad-example
 Attempt to embed a footnote in this codeblock, it won't work[^2].
 However, embedded hyperlinks do appear to work, like [this one](https://google.com/example).
 ```
-
-> [!example]
-> Attempt to embed a footnote into this callout, it won't work[^2].
-> However, embedded hyperlinks do appear to work, like [this one](https://google.com/example).
 
 It is therefore recommended to avoid embedding footnotes in Admonition code blocks and to use inline hyperlinks instead.
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Emoji Toolbar.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Emoji Toolbar.md
@@ -71,9 +71,8 @@ The following emojis are currently used as special search tags for notes:
 	* ⚔️ - Tool
 	* 🕳️ - Vulnerability
 
-```ad-info
-Currently, there is no restriction on using the same emoji as a search tag for new primary categories or content types (e.g., you can have a primary category with the search tag "💯New_Category" and a content type with the search tag "💯New_Content_Type"). This is a deliberate design choice to account for scenarios where the list of compatible emojis has been exhausted (an unlikely scenario given Emoji Toolbar theoretically supports [at least 3,790 emojis as of September 2024](https://emojipedia.org/faq#how-many)) and where users create loosely related content types (e.g., two content types with the search tags "⛏️Offensive_Tool" and "⛏️Defensive_Tool").
-```
+> [!info]
+> Currently, there is no restriction on using the same emoji as a search tag for new primary categories or content types (e.g., you can have a primary category with the search tag "💯New_Category" and a content type with the search tag "💯New_Content_Type"). This is a deliberate design choice to account for scenarios where the list of compatible emojis has been exhausted (an unlikely scenario given Emoji Toolbar theoretically supports [at least 3,790 emojis as of September 2024](https://emojipedia.org/faq#how-many)) and where users create loosely related content types (e.g., two content types with the search tags "⛏️Offensive_Tool" and "⛏️Defensive_Tool").
 
 The following emojis are always reserved for vault administration and cannot be used to create new search tags via the [[Templater]] plugin script:
 

--- a/Adversary Simulation Zettelkasten/03 - Content/GetUserSPNs.py.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/GetUserSPNs.py.md
@@ -93,15 +93,13 @@ Additionally, avoid requesting all SPNs in bulk. Multiple SPN requests in a shor
 GetUserSPNs.py -request-user <target-user> -dc-ip <dc-ipv4-address> -outputfile <filename> <domain.full>/<user>
 ```
 
-```ad-todo
-Add discussion about encryption types, the `(servicePrincipalName=*)` LDAP query, and ticket request parameters.
-```
+> [!todo]
+> Add discussion about encryption types, the `(servicePrincipalName=*)` LDAP query, and ticket request parameters.
 
 ## Under-the-Hood
 
-```ad-todo
-Reverse engineer `GetUserSPNs.py` source code, analyze ticket exchanges in [Wireshark](https://www.wireshark.org/), and document detailed function flow.
-```
+> [!todo]
+> Reverse engineer `GetUserSPNs.py` source code, analyze ticket exchanges in [Wireshark](https://www.wireshark.org/), and document detailed function flow.
 
 ## Help Menu
 
@@ -152,8 +150,9 @@ connection:
 
 | Hyperlink                                                                                               | Info                                   |
 | ------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| [GetUserSPNs.py, Fortra](https://github.com/fortra/impacket/blob/master/examples/GetUserSPNs.py)        | GitHub repository for `GetUserSPNs.pu` |
+| [GetUserSPNs.py, Fortra](https://github.com/fortra/impacket/blob/master/examples/GetUserSPNs.py)        | GitHub repository for `GetUserSPNs.py` |
 | [Steal or Forge Kerberos Tickets: Kerberoasting, MITRE](https://attack.mitre.org/techniques/T1558/003/) | MITRE ATT&CK entry for "Kerberoasting" |
+|                                                                                                         |                                        |
 
 [^1]: GetUserSPNs.py, Fortra, https://github.com/fortra/impacket/blob/master/examples/GetUserSPNs.py
 [^2]: Attacking Microsoft Kerberos Kicking the Guard Dog of Hades, Tim Medin, https://youtu.be/PUyhlN-E5MU

--- a/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Callouts.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Callouts.md
@@ -1,0 +1,449 @@
+---
+aliases:
+tags:
+  - 📝Basic
+primary categories:
+  - "[[Vault Administration]]"
+secondary categories:
+  - "[[Obsidian]]"
+type: Basic
+---
+# [[Obsidian - Callouts]]
+
+---
+
+## Overview
+
+As of [Obsidian v0.14.0](https://obsidian.md/changelog/2022-03-14-desktop-v0.14.0/), Obsidian natively supports callout boxes[^1] (also known as admonitions). Callouts allow you to create visually distinct blocks with different icons, colors, and styles directly in your notes without requiring community plugins.
+
+Callouts are useful for:
+- Highlighting important information, warnings, or tips
+- Creating structured documentation with clear visual hierarchy
+- Drawing attention to critical details within your notes
+- Organizing content into categorized blocks
+
+---
+
+## Basic Syntax
+
+The basic syntax for callouts uses blockquote notation with a special identifier:
+
+```markdown
+> [!callout-type]
+> Your content here.
+```
+
+**Example:**
+
+```markdown
+> [!note]
+> This is a basic note callout.
+```
+
+> [!note]
+> This is a basic note callout.
+
+---
+
+## Supported Callout Types
+
+Obsidian supports multiple built-in callout types, each with distinct colors and icons:
+
+### Informational Callouts
+
+```markdown
+> [!note]
+> General notes, references, or related information.
+
+> [!info]
+> Highlighting helpful information.
+
+> [!todo]
+> Tasks or items to complete.
+```
+
+> [!note]
+> General notes, references, or related information.
+
+> [!info]
+> Highlighting helpful information.
+
+> [!todo]
+> Tasks or items to complete.
+
+### Positive Callouts
+
+```markdown
+> [!success]
+> Indicating completion, success, or confirmation messages.
+
+> [!check]
+> Checkpoints or validated information.
+
+> [!done]
+> Completed tasks or finished items.
+```
+
+> [!success]
+> Indicating completion, success, or confirmation messages.
+
+> [!check]
+> Checkpoints or validated information.
+
+> [!done]
+> Completed tasks or finished items.
+
+### Cautionary Callouts
+
+```markdown
+> [!question]
+> Questions, FAQs, or prompts for further thinking.
+
+> [!help]
+> Help information or assistance needed.
+
+> [!warning]
+> Calling out cautions, risks, or important alerts.
+
+> [!caution]
+> Situations requiring careful attention.
+
+> [!attention]
+> Items requiring immediate focus.
+```
+
+> [!question]
+> Questions, FAQs, or prompts for further thinking.
+
+> [!help]
+> Help information or assistance needed.
+
+> [!warning]
+> Calling out cautions, risks, or important alerts.
+
+> [!caution]
+> Situations requiring careful attention.
+
+> [!attention]
+> Items requiring immediate focus.
+
+### Negative Callouts
+
+```markdown
+> [!failure]
+> Noting missing items, failed tasks, or critical issues.
+
+> [!fail]
+> Failed operations or unsuccessful attempts.
+
+> [!missing]
+> Missing information or incomplete sections.
+
+> [!danger]
+> Highlighting severe problems, errors, or urgent issues.
+
+> [!error]
+> Error messages or problematic situations.
+
+> [!bug]
+> Tracking bugs, issues, or debugging notes.
+```
+
+> [!failure]
+> Noting missing items, failed tasks, or critical issues.
+
+> [!fail]
+> Failed operations or unsuccessful attempts.
+
+> [!missing]
+> Missing information or incomplete sections.
+
+> [!danger]
+> Highlighting severe problems, errors, or urgent issues.
+
+> [!error]
+> Error messages or problematic situations.
+
+> [!bug]
+> Tracking bugs, issues, or debugging notes.
+
+### Additional Callouts
+
+```markdown
+> [!abstract]
+> Summarizing content or providing an overview.
+
+> [!tip]
+> Helpful tips, best practices, or important details.
+
+> [!example]
+> Code examples, demonstrations, or sample content.
+
+> [!quote]
+> Highlighting quotes, citations, or references.
+
+> [!cite]
+> Formal citations or references.
+```
+
+> [!abstract]
+> Summarizing content or providing an overview.
+
+> [!tip]
+> Helpful tips, best practices, or important details.
+
+> [!example]
+> Code examples, demonstrations, or sample content.
+
+> [!quote]
+> Highlighting quotes, citations, or references.
+
+> [!cite]
+> Formal citations or references.
+
+---
+
+## Callout Titles
+
+You can customize the title of any callout by adding text after the callout type:
+
+```markdown
+> [!tip] Pro Tip
+> Custom titles help organize and label your callouts.
+```
+
+> [!tip] Pro Tip
+> Custom titles help organize and label your callouts.
+
+To create a callout without any content (essentially a title-only callout), only populate the title line:
+
+```markdown
+> [!warning] This callout is title-only
+```
+
+> [!warning] This callout is title-only
+
+---
+
+## Collapsible Callouts
+
+Callouts can be made collapsible (foldable) using `+` or `-` modifiers:
+
+### Expanded by Default
+
+Use `+` to create a callout that is expanded by default:
+
+```markdown
+> [!note]+ Click to Collapse
+> This callout starts expanded and can be collapsed by clicking the arrow.
+> 
+> It can contain multiple paragraphs and other content.
+```
+
+> [!note]+ Click to Collapse
+> This callout starts expanded and can be collapsed by clicking the arrow.
+> 
+> It can contain multiple paragraphs and other content.
+
+### Collapsed by Default
+
+Use `-` to create a callout that is collapsed by default:
+
+```markdown
+> [!warning]- Click to Expand
+> This callout starts collapsed and must be clicked to view its contents.
+> 
+> This is useful for hiding detailed information that isn't always needed.
+```
+
+> [!warning]- Click to Expand
+> This callout starts collapsed and must be clicked to view its contents.
+> 
+> This is useful for hiding detailed information that isn't always needed.
+
+---
+
+## Nested Callouts
+
+Callouts can be nested inside other callouts for creating hierarchical information structures:
+
+```markdown
+> [!note] Parent Callout
+> This is the main callout.
+> 
+> > [!warning] Nested Warning
+> > This warning is nested inside the note callout.
+> > 
+> > > [!tip] Doubly Nested Tip
+> > > You can nest callouts multiple levels deep.
+> 
+> Back to the parent callout content.
+```
+
+> [!note] Parent Callout
+> This is the main callout.
+> 
+> > [!warning] Nested Warning
+> > This warning is nested inside the note callout.
+> > 
+> > > [!tip] Doubly Nested Tip
+> > > You can nest callouts multiple levels deep.
+> 
+> Back to the parent callout content.
+
+---
+
+## Markdown Support in Callouts
+
+Callouts support full Markdown formatting, including:
+
+### Lists
+
+```markdown
+> [!tip] Red Team TTPs
+> - Reconnaissance
+> - Initial Access
+> - Execution
+> - Persistence
+> - Privilege Escalation
+```
+
+> [!tip] Red Team TTPs
+> - Reconnaissance
+> - Initial Access
+> - Execution
+> - Persistence
+> - Privilege Escalation
+
+### Code Blocks
+
+```markdown
+> [!example] PowerShell Command
+> ```powershell
+> Get-ADUser -Filter * -Properties LastLogonDate | 
+>   Select-Object Name, LastLogonDate
+> ```
+```
+
+> [!example] PowerShell Command
+> ```powershell
+> Get-ADUser -Filter * -Properties LastLogonDate | 
+>   Select-Object Name, LastLogonDate
+> ```
+
+### Links and Wikilinks
+
+```markdown
+> [!info] Related Topics
+> See also: [[Active Directory]], [[Kerberoasting]], and [[PowerShell]]
+> 
+> External resource: [MITRE ATT&CK](https://attack.mitre.org/)
+```
+
+> [!info] Related Topics
+> See also: [[Active Directory]], [[Kerberoasting]], and [[PowerShell]]
+> 
+> External resource: [MITRE ATT&CK](https://attack.mitre.org/)
+
+### Tables
+
+```markdown
+> [!abstract] Port Summary
+> | Port | Service | Protocol |
+> | ---- | ------- | -------- |
+> | 80   | HTTP    | TCP      |
+> | 443  | HTTPS   | TCP      |
+> | 22   | SSH     | TCP      |
+```
+
+> [!abstract] Port Summary
+> | Port | Service | Protocol |
+> | ---- | ------- | -------- |
+> | 80   | HTTP    | TCP      |
+> | 443  | HTTPS   | TCP      |
+> | 22   | SSH     | TCP      |
+
+---
+
+## Callout Type Aliases
+
+Many callout types have aliases that produce the same styling. Use whichever name best fits your context:
+
+| Primary Type | Aliases                |
+| ------------ | ---------------------- |
+| `note`       | `seealso`              |
+| `abstract`   | `summary`, `tldr`      |
+| `info`       | —                      |
+| `todo`       | —                      |
+| `tip`        | `hint`, `important`    |
+| `success`    | `check`, `done`        |
+| `question`   | `help`, `faq`          |
+| `warning`    | `caution`, `attention` |
+| `failure`    | `fail`, `missing`      |
+| `danger`     | `error`                |
+| `bug`        | —                      |
+| `example`    | —                      |
+| `quote`      | `cite`                 |
+
+---
+
+## Limitations
+
+### Footnotes
+
+Footnotes cannot be embedded directly within callout blocks. They must be placed outside the callout:
+
+```markdown
+> [!note]
+> This callout attempts to use a footnote[^2].
+```
+
+> [!note]
+> This callout attempts to use a footnote[^2].
+
+It is advised to use inline links instead:
+
+```markdown
+> [!note]
+> This callout uses an [inline link](https://example.com) instead of a footnote.
+```
+
+> [!note]
+> This callout uses an [inline link](https://example.com) instead of a footnote.
+
+### Dataview Queries
+
+Dataview queries within callouts may not render correctly in all contexts. Test thoroughly if using dynamic content inside callouts.
+
+---
+
+## Comparison with Admonition Plugin
+
+| Feature               | Native Callouts | Admonition Plugin               |
+| --------------------- | --------------- | ------------------------------- |
+| Installation Required | No              | Yes                             |
+| Syntax                | `> [!type]`     | ` ```ad-type `                  |
+| Collapsible           | Yes (`+`, `-`)  | Yes (`collapse:`)               |
+| Custom Colors         | Limited         | Yes (RGB values)                |
+| Markdown Support      | Full            | Full                            |
+| Custom Callout Types  | Via CSS         | Built-in UI                     |
+| Performance           | Native (faster) | Plugin (slight overhead)        |
+| Future Compatibility  | High            | Dependent on plugin maintenance |
+
+It is recomended to use native callouts for new notes. The [[Admonition]] plugin remains available for legacy compatibility and advanced customization needs.
+
+## Resources
+
+| Hyperlink                                                                                                                                      | Info                                                                 |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [Callouts, Obsidian Help](https://help.obsidian.md/Editing+and+formatting/Callouts)                                                            | Official Obsidian documentation for callouts                         |
+| [0.14.0 Desktop, Obsidian Changelog](https://obsidian.md/changelog/2022-03-14-desktop-v0.14.0/)                                                | Release notes introducing native callout support                     |
+| [How to make Custom Callouts in Obsidian, Brianna Laird](https://briannalaird.com/content/blog-posts/2025-06-17-making-callouts-obsidian.html) | Community member-published guide on styling and customizing callouts |
+
+[^1]: Callouts, Obsidian Help, https://help.obsidian.md/Editing+and+formatting/Callouts
+[^2]: Example Page, Google, https://google.com/example
+
+---
+
+*Created Date*: <%+tp.file.creation_date("MMMM Do YYYY (HH:mm a)")%>  
+*Last Modified Date*: <%+tp.file.last_modified_date("MMMM Do YYYY (HH:mm a)")%>

--- a/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Custom CSS.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Custom CSS.md
@@ -32,21 +32,19 @@ To enable custom styling within Obsidian, you'll need to:
 ### 1. Colorized Graph Nodes
 
 #### Description
-Recolor  `unresolved` or non-existent notes to show up in graph view as dark red (#CF4747).
+Recolor `unresolved` or non-existent notes to show up in graph view as dark red (#CF4747).
 
 While Obsidian exposes the ability to colorize the graph view using groups, there doesnt seem to yet be a way to colorize unresolved notes. For this we'll use a CSS snippet. 
 
 #### CSS Snippet
 
-```ad-example
-title: Colorize Graph Nodes
-collapse: Yes
-icon: triforce
-
-.graph-view.color-fill-unresolved { 
- color: #CF4747; !important
-}
-```
+> [!example] Colorize Graph Nodes
+> 
+> ```css
+> .graph-view.color-fill-unresolved {
+> color: #CF4747; !important
+> }
+> ```
 
 #### Example
 
@@ -62,60 +60,58 @@ Add colored 'pill' styling around search tags.
 
 #### CSS Snippet
 
-```ad-example
-title: Colorize Graph Nodes
-collapse: Yes
-icon: triforce
-
-/* 
-Pill-style colorized tags in preview AND editor panes
-*/
-
-a.tag,
-div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-begin,
-div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-end {
-  background-color: var(--text-accent);
-  border: none;
-  color: white;
-  font-size: 12px;
-  padding: 1px 8px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  margin: 0px 0px;
-  cursor: pointer;
-  border-radius: 12px;
-}
-
-a.tag:hover {
-  background-color: var(--text-accent-hover);
-  color: white
-}
-
-div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-begin {
-  display: none;
-}
-
-div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-end:before {
-  content: '#';
-}
-
-.tag[href^="#obsidian"] {
-  background-color: #4d3ca6;
-}
-
-.tag[href^="#important"] {
-  background-color: red;
-}
-
-.tag[href^="#complete"] {
-  background-color: green;
-}
-
-.tag[href^="#inprogress"] {
-  background-color: orange;
-}
-```
+> [!example] Colorize Graph Nodes
+> 
+> ```css
+> /* 
+> Pill-style colorized tags in preview AND editor panes
+> */
+> 
+> a.tag,
+> div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-begin,
+> div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-end {
+>   background-color: var(--text-accent);
+>   border: none;
+>   color: white;
+>   font-size: 12px;
+>   padding: 1px 8px;
+>   text-align: center;
+>   text-decoration: none;
+>   display: inline-block;
+>   margin: 0px 0px;
+>   cursor: pointer;
+>   border-radius: 12px;
+> }
+> 
+> a.tag:hover {
+>   background-color: var(--text-accent-hover);
+>   color: white
+> }
+> 
+> div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-begin {
+>   display: none;
+> }
+> 
+> div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-end:before {
+>   content: '#';
+> }
+> 
+> .tag[href^="#obsidian"] {
+>   background-color: #4d3ca6;
+> }
+> 
+> .tag[href^="#important"] {
+>   background-color: red;
+> }
+> 
+> .tag[href^="#complete"] {
+>   background-color: green;
+> }
+> 
+> .tag[href^="#inprogress"] {
+>   background-color: orange;
+> }
+> ```
 
 #### Example
 
@@ -125,35 +121,36 @@ div:not(.CodeMirror-activeline) > .CodeMirror-line span.cm-hashtag-end:before {
 
 #### Description
 
-Using the VIM community plugin, colors the current line in focus  when in insert mode for improved readability
+Using the VIM community plugin, colors the current line in focus when in insert mode for improved readability
 
 #### CSS Snippet
 
-```ad-example
-~~~CSS
-/* Modified by Christian (Chhrriissyy#6548). Original by MooddooM */
-/* This version sets the line focus for both edit and insert mode. */
-/* If you want to make it edit mode only, add the `.cm-fat-cursor` CSS class selector to both light & dark mode. /*
-
-/* Cursor color in normal vim mode and opacity */
-.cm-fat-cursor .CodeMirror-cursor, .cm-animate-fat-cursor {
-    width: 0.5em;
-    background: #d65d0e;
-    opacity: 60% !important;
-}
-
-/* LIGHT MODE */
-/*if you want the highlight to present in both normal and insert mode of vim*/
-.theme-light /* .cm-fat-cursor */ .CodeMirror-activeline .CodeMirror-linebackground{
-    background-color: #2f2f2f;
-    opacity: 10%
-}
-
-/* DARK MODE */
-.theme-dark /* .cm-fat-cursor */ .CodeMirror-activeline .CodeMirror-linebackground {
-    background-color: #f1f1f1;
-    opacity: 30%;
-```
+> [!example]
+> 
+> ```css
+> /* Modified by Christian (Chhrriissyy#6548). Original by MooddooM */
+> /* This version sets the line focus for both edit and insert mode. */
+> /* If you want to make it edit mode only, add the `.cm-fat-cursor` CSS class selector to both light & dark mode. /*
+> 
+> /* Cursor color in normal vim mode and opacity */
+> .cm-fat-cursor .CodeMirror-cursor, .cm-animate-fat-cursor {
+>     width: 0.5em;
+>     background: #d65d0e;
+>     opacity: 60% !important;
+> }
+> 
+> /* LIGHT MODE */
+> /*if you want the highlight to present in both normal and insert mode of vim*/
+> .theme-light /* .cm-fat-cursor */ .CodeMirror-activeline .CodeMirror-linebackground{
+>     background-color: #2f2f2f;
+>     opacity: 10%
+> }
+> 
+> /* DARK MODE */
+> .theme-dark /* .cm-fat-cursor */ .CodeMirror-activeline .CodeMirror-linebackground {
+>     background-color: #f1f1f1;
+>     opacity: 30%;
+> ```
 
 #### Example
 
@@ -167,25 +164,25 @@ In preview mode, enlarges images/gifs when you hover over them.
 
 #### CSS Snippet
 
-```ad-example
-~~~CSS
-.markdown-preview-view img {
-  display: block;
-  margin-top: 20pt;
-  margin-bottom: 20pt;
-  margin-left: auto;
-  margin-right: auto;
-  width: 50%;  /* experiment with values */
-  transition:transform 0.25s ease;
-}
-
-.markdown-preview-view img:hover {
-    -webkit-transform:scale(1.8); /* experiment with values */
-    transform:scale(2);
-    
-}
-
-```
+> [!example]
+> 
+> ```css
+> .markdown-preview-view img {
+>   display: block;
+>   margin-top: 20pt;
+>   margin-bottom: 20pt;
+>   margin-left: auto;
+>   margin-right: auto;
+>   width: 50%;  /* experiment with values */
+>   transition:transform 0.25s ease;
+> }
+> 
+> .markdown-preview-view img:hover {
+>     -webkit-transform:scale(1.8); /* experiment with values */
+>     transform:scale(2);
+>     
+> }
+> ```
 
 #### Example
 
@@ -199,17 +196,17 @@ Embedded windows or references to Obsidian locations will render expanded and no
 
 #### CSS Snippet
 
-```ad-example
-~~~CSS
-/* Remove scroll bar from transclusions */
-.markdown-preview-view .markdown-embed-content {
-max-height: unset;
-}
-.markdown-preview-view .markdown-embed-content > .markdown-preview-view {
-max-height: unset;
-}
-
-```
+> [!example]
+> 
+> ```css
+> /* Remove scroll bar from transclusions */
+> .markdown-preview-view .markdown-embed-content {
+> max-height: unset;
+> }
+> .markdown-preview-view .markdown-embed-content > .markdown-preview-view {
+> max-height: unset;
+> }
+> ```
 
 
 #### Example
@@ -220,37 +217,38 @@ max-height: unset;
 
 #### Description
 
-Attempt to make externally embedded content  more responsive
+Attempt to make externally embedded content more responsive
 
 #### CSS Snippet
 
-```ad-example
-~~~CSS
-/* responsive img/iframe defintion */
-[style*="--aspect-ratio"] > :first-child {
-  width: 100%;
-}
-
-[style*="--aspect-ratio"] > img {  
-  height: auto;
-}
-
-@supports (--custom:property) {
-  [style*="--aspect-ratio"] {
-    position: relative;
-  }
-  [style*="--aspect-ratio"]::before {
-    content: "";
-    display: block;
-    padding-bottom: calc(100% / (var(--aspect-ratio)));
-  }  
-  [style*="--aspect-ratio"] > :first-child {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-  }  
-}
+> [!example]
+> 
+> ```css
+> /* responsive img/iframe defintion */
+> [style*="--aspect-ratio"] > :first-child {
+>   width: 100%;
+> }
+> 
+> [style*="--aspect-ratio"] > img {  
+>   height: auto;
+> }
+> 
+> @supports (--custom:property) {
+>   [style*="--aspect-ratio"] {
+>     position: relative;
+>   }
+>   [style*="--aspect-ratio"]::before {
+>     content: "";
+>     display: block;
+>     padding-bottom: calc(100% / (var(--aspect-ratio)));
+>   }  
+>   [style*="--aspect-ratio"] > :first-child {
+>     position: absolute;
+>     top: 0;
+>     left: 0;
+>     height: 100%;
+>   }  
+> }
 
 ```
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Getting Started.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Getting Started.md
@@ -16,21 +16,22 @@ type: Basic
 
 This vault was inspired by TrustedSec's research on using Obsidian[^1] for collaborative offensive security knowledge management.
 
-```ad-todo
-Once the installation and configuration scripts have been set up, add the following line:
-
-``It is recommended that you run the installation and configuration script (`install.ps1` for Windows, `install.sh` for NIX-like systems) prior to using this vault; more instructions are available in the `README.md` file.``
-```
+> [!todo]
+> Once the installation and configuration scripts have been added, introduce the following line to this page:
+> 
+> ``It is recommended that you run the installation and configuration script (`install.ps1` for Windows, `install.sh` for NIX-like systems) prior to using this vault; more instructions are available in the `README.md` file.``
 
 If you're just getting started, be sure to check out the complete blog pertaining to Obsidian on TrustedSec's website[^2]. In addition, dig into a few of the resources cited below which go into substantially more detail surrounding many of the how-tos of Obsidian and the benefits of maintaining a digital [[Zettelkasten]].
 
 For instructions on how to add your own content and categories, navigate to the [[Vault Structure and Note Creation]] page. Be sure to check out [[Obsidian - Plugins]] along with the individual pages for the following required vault plugins:
 
-* [[Admonition]]
 * [[Dataview]]
 * [[Emoji Toolbar]]
 * [[Obsidian Git]]
 * [[Templater]]
+
+> [!tip] Native Callouts
+> As of Obsidian v0.14.0, callout boxes (admonitions) are natively supported without requiring the [[Admonition]] community plugin. See [[Obsidian - Callouts]] for usage instructions and examples.
 
 Everyone's learning style is different. It is therefore encouraged that you make your own changes to this vault to best accommodate your preferences and workflow.
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Linking Content.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Linking Content.md
@@ -42,9 +42,8 @@ type: Basic
 		
 ![[Pasted image 20210907120756.png]]
 
-```ad-important
-If you're using included CSS snippets nonexistent nodes become a bit more visable as they're colored dark red.
-```
+> [!important]
+> If you're using included CSS snippets then nonexistent nodes become a bit more visible as they're colored dark red.
 
 ### Before:
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Plugins.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Obsidian - Plugins.md
@@ -14,11 +14,10 @@ type: Basic
 
 This vault uses [Obsidian Community Plugins](https://help.obsidian.md/community-plugins) to automate the process of note creation, source control, data querying, and other essential functions.
 
-```ad-todo
-Once the installation and configuration scripts have been set up, add the following line:
-
-``The installation and configuration scripts (`install.ps1` for Windows, `install.sh` for NIX-like systems) automate the installation and configuration process of the required community plugins.``
-```
+> [!todo]
+> Once the installation and configuration scripts have been added, introduce the following line to this page:
+> 
+> ``It is recommended that you run the installation and configuration script (`install.ps1` for Windows, `install.sh` for NIX-like systems) prior to using this vault; more instructions are available in the `README.md` file.``
 
 ## Required Plugins
 
@@ -42,25 +41,34 @@ The [[Templater]][^2] plugin extends Obsidian's built-in template functionality 
 
 The [[Dataview]][^3] plugin transforms Obsidian into a powerful database by enabling SQL-like queries over your notes and their metadata. It can generate dynamic tables, lists, and charts based on tags, frontmatter, and content, making it possible to create automated indexes and dashboards. This plugin is crucial for organizing and discovering content within large knowledge bases.
 
-### Admonition
-
-<iframe src="https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/obsidian-admonition"></iframe>
-
-The [[Admonition]][^4] plugin adds support for visually distinct code blocks that can highlight important information, warnings, tips, and other content types. It provides a variety of predefined styles and supports custom formatting, making documentation more readable and professionally formatted. These code blocks help organize information hierarchically and draw attention to critical details.
-
 ### Emoji Toolbar
 
 <iframe src="https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/obsidian-emoji-toolbar"></iframe>
 
-The [[Emoji Toolbar]][^5] plugin provides a user-friendly interface for inserting emojis and Unicode symbols into notes. Beyond basic emoji insertion, it supports custom emoji sets and can be configured to work with specific tagging systems. In this vault, it facilitates the consistent use of emoji-based categorization and visual organization of primary categories and content types.
+The [[Emoji Toolbar]][^4] plugin provides a user-friendly interface for inserting emojis and Unicode symbols into notes. Beyond basic emoji insertion, it supports custom emoji sets and can be configured to work with specific tagging systems. In this vault, it facilitates the consistent use of emoji-based categorization and visual organization of primary categories and content types.
 
 ## Optional Plugins
 
-No plugins are considered optional at this time.
-
-```ad-todo
+> [!todo]
 Experiment more with suggested plugins and add to this section as-needed.
-```
+
+### Admonition
+
+<iframe src="https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/obsidian-admonition"></iframe>
+
+> [!important] Native Callout Support
+> As of [Obsidian v0.14.0](https://obsidian.md/changelog/2022-03-19-desktop-v0.14.0/), callout boxes (admonitions) are natively supported without requiring this plugin. For most use cases, native callouts are recommended.
+
+The [[Admonition]][^5] plugin adds support for visually distinct code blocks that can highlight important information, warnings, tips, and other content types. It provides a variety of predefined styles and supports custom formatting, making documentation more readable and professionally formatted. These code blocks help organize information hierarchically and draw attention to critical details.
+
+The Admonition plugin is now considered optional for this vault. While Obsidian's native callouts provide the core functionality for creating visually distinct information blocks, you may still choose to install the Admonition plugin for:
+
+- **Legacy compatibility**: If working with vaults that use the older syntax (` ```ad-type `)
+- **Advanced customization**: Access to additional styling options beyond native callouts
+- **Custom callout types**: Creating specialized admonition types with unique styling
+- **RGB color control**: Fine-grained color customization not available in native callouts
+
+For new notes, it is recommended to use native callouts (`> [!type]` syntax) for better performance and future compatibility. See the [[Obsidian - Callouts]] page for a detailed comparison between the plugin and native callout features.
 
 ___
 
@@ -78,8 +86,8 @@ ___
 [^1]: Obsidian Git Plugin, Denis Olehov, https://github.com/denolehov/obsidian-git
 [^2]: Templater Plugin, SilentVoid13, https://github.com/SilentVoid13/Templater
 [^3]: Dataview Plugin, Michael Brenan, https://github.com/blacksmithgu/obsidian-dataview
-[^4]: Admonition Plugin, Jeremy Valentine, https://github.com/javalent/admonitions
-[^5]: Emoji Toolbar Plugin, oliveryh, https://github.com/oliveryh/obsidian-emoji-toolbar
+[^4]: Emoji Toolbar Plugin, oliveryh, https://github.com/oliveryh/obsidian-emoji-toolbar
+[^5]: Admonition Plugin, Jeremy Valentine, https://github.com/javalent/admonitions
 
 ***
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Steal or Forge Kerberos Tickets - Kerberoasting (T1558.003).md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Steal or Forge Kerberos Tickets - Kerberoasting (T1558.003).md
@@ -19,9 +19,8 @@ type: TTP
 ***
 ## Overview
 
-```ad-info
-The content in this page is directly adapted from the [MITRE ATT&CK](https://attack.mitre.org/techniques/T1558/003/) framework for personal reference. Please consult the original MITRE ATT&CK entry for the most up-to-date and complete information.
-```
+> [!info]
+> The content in this page is directly adapted from the [MITRE ATT&CK](https://attack.mitre.org/techniques/T1558/003/) framework for personal reference. Please consult the original MITRE ATT&CK entry for the most up-to-date and complete information.
 
 Adversaries may abuse a valid Kerberos ticket-granting ticket (TGT) or sniff network traffic to obtain a ticket-granting service (TGS) ticket that may be vulnerable to [Brute Force](https://attack.mitre.org/techniques/T1110)[^1][^2].
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Templater.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Templater.md
@@ -36,14 +36,11 @@ type: Basic
 
 ## Configuration
 
-```ad-info
-### Not Seeing this stylized in *PREVIEW* mode?
-#### Try installing the community plugin, 'Admonition'
-
-1. *Template Folder Location*: 04 - Templates
-2. *Trigger Templater on New File Creation*: True
-3. *Empty File Template*: 04 - Templates/0400 - Gen_Note
-```
+> [!info] Templater Configuration Instructions
+> ### Required Values
+> 1. *Template Folder Location*: `04 - Templates`
+> 2. *Trigger Templater on New File Creation*: **True**
+> 3. *Empty File Template*: `04 - Templates/0400 - Gen_Note`
 
 To help manage **incomplete**, **NULL**, or **'Untitled'** notes, it can  be helpful to assign `Settings > Files & Links > Folder to Create New Notes in` to `.trash`. Since our **0400 - Gen_Note** template handles moving successfully created notes to their appropriate folders, the categories listed above will automatically end up in trash. 
 

--- a/Adversary Simulation Zettelkasten/03 - Content/Vault Structure and Note Creation.md
+++ b/Adversary Simulation Zettelkasten/03 - Content/Vault Structure and Note Creation.md
@@ -116,9 +116,8 @@ The emoji selection interface provides categorized options relevant to adversary
 
 Users can choose a search tag emoji from the categorized options list. Alternatively, they can select the `"🎲 Random selection"` option to allow the system to handle search tag emoji selection. The user can also manually enter a search tag emoji by selecting the `"✏️ Enter emoji manually"` option.
 
-```ad-tip
-The [[Emoji Toolbar]] keyboard will not be available to you when you are redirected to the manual emoji entry system prompt, so it is advised to have your desired emoji copied to your clipboard before this step.
-```
+> [!tip]
+> The [[Emoji Toolbar]] keyboard will not be available to you when you are redirected to the manual emoji entry system prompt, so it is advised to have your desired emoji copied to your clipboard before this step.
 
 #### Emoji Validation and Error Handling
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Basic/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Basic/Body.md
@@ -1,5 +1,4 @@
 ## Overview
 
-```ad-tip
-Use this template for notes that do not fall neatly into pre-existing content types.
-```
+> [!tip]
+> Use this template for notes that do not fall neatly into pre-existing content types.

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Biography/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Biography/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Document timelines, notable contributions, and lasting impact of individuals significant to cybersecurity or your professional development.
-```
+> [!tip]
+> Document timelines, notable contributions, and lasting impact of individuals significant to cybersecurity or your professional development.
 
 ## Timeline
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Case Study/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Case Study/Body.md
@@ -1,23 +1,19 @@
 ## Overview
 
-````ad-tip
-Document and reflect on security events, linking them to related TTPs, tools, and other notes.
-```ad-danger
-title: Data Handling Warning
-collapse: none
-
-**DO NOT upload sensitive information to your Zettelkasten if you do not control where the data resides.**
-
-Before documenting events, consider:
-- **Sensitive data**: Remove client names, real IP addresses, credentials, and identifying information
-- **Confidentiality**: Respect NDAs, client agreements, and organizational policies
-- **Storage security**: Ensure your vault location meets appropriate security standards
-- **Access controls**: Verify who can access your knowledge base
-- **Data classification**: Follow proper handling procedures for sensitive information
-
-**Best Practice**: Focus on techniques, methodologies, and lessons learned rather than specific sensitive details. Use sanitized examples and placeholder values where needed.
-```
-````
+> [!tip]
+> Document and reflect on security events, linking them to related TTPs, tools, and other notes.
+> > [!danger] Data Handling Warning
+> > 
+> > **DO NOT upload sensitive information to your Zettelkasten if you do not control where the data resides.**
+> > 
+> > Before documenting events, consider:
+> > - **Sensitive data**: Remove client names, real IP addresses, credentials, and identifying information
+> > - **Confidentiality**: Respect NDAs, client agreements, and organizational policies
+> > - **Storage security**: Ensure your vault location meets appropriate security standards
+> > - **Access controls**: Verify who can access your knowledge base
+> > - **Data classification**: Follow proper handling procedures for sensitive information
+> > 
+> > **Best Practice**: Focus on techniques, methodologies, and lessons learned rather than specific sensitive details. Use sanitized examples and placeholder values where needed.
 
 ## Environment Overview
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Command/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Command/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Document the requirements, syntax, and usage of a specific command or variants of a command.
-```
+> [!tip]
+> Document the requirements, syntax, and usage of a specific command or variants of a command.
 
 ## Requirements
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/IOC/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/IOC/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Catalog indicators of compromise linked to specific threat actors, tools, or techniques.
-```
+> [!tip]
+> Catalog indicators of compromise linked to specific threat actors, tools, or techniques.
 
 ## Details
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Idea/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Idea/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Capture and develop concepts for future projects, tool improvements, or novel attack techniques.
-```
+> [!tip]
+> Capture and develop concepts for future projects, tool improvements, or novel attack techniques.
 
 ## Context/Background
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Infrastructure/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Infrastructure/Body.md
@@ -1,9 +1,7 @@
 ## Overview
 
-```ad-tip
-Document system architectures and component relationships with high-level diagrams and explanatory overviews.
-```
+> [!tip]
+> Document system architectures and component relationships with high-level diagrams and explanatory overviews.
 
-```ad-todo
-Insert graphic
-```
+> [!todo]
+> Insert graphic.

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Lab Setup/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Lab Setup/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Provide step-by-step instructions for configuring specific testing environments, applications, or vulnerable targets.
-```
+> [!tip]
+> Provide step-by-step instructions for configuring specific testing environments, applications, or vulnerable targets.
 
 ## Requirements
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Mindmap/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Mindmap/Body.md
@@ -1,9 +1,7 @@
 ## Overview
 
-```ad-tip
-Organize and embed your preferred visual study resources and conceptual learning materials.
-```
+> [!tip]
+> Organize and embed your preferred visual study resources and conceptual learning materials.
 
-```ad-todo
-Insert graphic
-```
+> [!todo]
+> Insert graphic.

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Payload/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Payload/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Document source code analysis and complete implementations of offensive security payloads and exploits.
-```
+> [!tip]
+> Document source code analysis and complete implementations of offensive security payloads and exploits.
 
 ## File Contents
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Playbook/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Playbook/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Create step-by-step procedures and checklists for completing specific operational objectives or security tasks.
-```
+> [!tip]
+> Create step-by-step procedures and checklists for completing specific operational objectives or security tasks.
 
 ## Steps
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Study Resources/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Study Resources/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Outline learning objectives, exercises, and key takeaways from courses, certifications, and training programs.
-```
+> [!tip]
+> Outline learning objectives, exercises, and key takeaways from courses, certifications, and training programs.
 
 ## Learning Objectives
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/TTP/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/TTP/Body.md
@@ -1,12 +1,10 @@
 ## Overview
 
-```ad-tip
-Document tactics, techniques, and procedures from the MITRE ATT&CK Framework.
-```
+> [!tip]
+> Document tactics, techniques, and procedures from the MITRE ATT&CK Framework.
 
-```ad-info
-The content in this page is directly adapted from the [MITRE ATT&CK](https://attack.mitre.org/techniques/T1558/003/) framework for personal reference. Please consult the original MITRE ATT&CK entry for the most up-to-date and complete information.
-```
+> [!info]
+> The content in this page is directly adapted from the [MITRE ATT&CK](https://attack.mitre.org/techniques/T1558/003/) framework for personal reference. Please consult the original MITRE ATT&CK entry for the most up-to-date and complete information.
 
 ## Procedure Examples
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Tool/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Tool/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Summarize tool capabilities, essential commands, OPSEC considerations, and operational requirements.
-```
+> [!tip]
+> Summarize tool capabilities, essential commands, OPSEC considerations, and operational requirements.
 
 ## Requirements
 

--- a/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Vulnerability/Body.md
+++ b/Adversary Simulation Zettelkasten/04 - Templates/04 - Content/Vulnerability/Body.md
@@ -1,8 +1,7 @@
 ## Overview
 
-```ad-tip
-Analyze technical details, exploitation methods, and remediation strategies for specific security flaws.
-```
+> [!tip]
+> Analyze technical details, exploitation methods, and remediation strategies for specific security flaws.
 
 ## Technical Details
 

--- a/README.md
+++ b/README.md
@@ -121,14 +121,13 @@ git init
 > [!NOTE]
 > In future releases of this template repository I hope to automate the installation and configuration of the required Obsidian community plugins via Bash and PowerShell scripts. For now, the user will have to manually install and configure these.
 
-The vault requires five community plugins for full functionality.
+The vault requires four community plugins for full functionality.
 
 | Plugin        | Key Settings                                        |
 | ------------- | --------------------------------------------------- |
 | [Obsidian Git](https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/obsidian-git) | *Auto commit-and-sync interval (minutes)*: `60`<br />*Auto pull interval (minutes)*: `10`<br />*Commit message on auto commit-and-sync*: `[hostname OR FirstLast] {{date}}`<br />*{{date}} placeholder format*: `MM-DD-YYYY HH:mm:ss`<br />*Push on commit-and-sync*: ON<br />*Pull on commit-and-sync*: ON |
 | [Templater](https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/templater-obsidian) | *Template folder location*: `04 - Templates`<br />*Trigger Templater on new file creation*: ON<br />*Enable folder templates*: ON<br />Add new folder templates for `01 - Primary Categories`, `02 - Secondary Categories`, and `03 - Content`<br />Set the folder templates' script to `04 - Templates/0400 - Gen_Note.md` |
 | [Dataview](https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/dataview) | *Enable inline queries*: ON<br /> *Inline query prefix*: `=`                     |
-| [Admonition](https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/obsidian-admonition) | *Add Copy Button*: ON                                     |
 | [Emoji Toolbar](https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/obsidian-emoji-toolbar) | Hotkey: <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>.</kbd> (default)                         |
 
 ### Detailed Plugin Setup Instructions
@@ -249,32 +248,7 @@ You may skip Obsidian Git installation and configuration if you are not working 
 </details>
 
 <details>
-<summary><strong>4. Admonition</strong></summary>
-
-#### Admonition Installation
-
-1. Search for "Admonition" in the community plugins browser and select the plugin by Jeremy Valentine
-
-![](/img/admonition-01.png)
-
-2. Click the "Install" button
-
-![](/img/admonition-02.png)
-
-3. After installation, click the "Enable" button
-
-![](/img/admonition-03.png)
-
-#### Admonition Configuration
-
-1. Click the "Options" button
-
-2. Toggle the "Add Copy Button" option to on for convenience
-
-</details>
-
-<details>
-<summary><strong>5. Emoji Toolbar</strong></summary>
+<summary><strong>4. Emoji Toolbar</strong></summary>
 
 #### Emoji Toolbar Installation
 
@@ -302,13 +276,50 @@ You may skip Obsidian Git installation and configuration if you are not working 
 
 </details>
 
+## Optional Plugins
+
+### Admonition
+
+While Obsidian now natively supports callout boxes (admonitions) as of [v0.14.0](https://publish.obsidian.md/hub/01+-+Community/Obsidian+Roundup/2022-03-19+Better+Citations+Workflows+%26+Native+Callout+Boxes), you may still wish to install the Admonition plugin for:
+- Advanced customization options beyond native callouts
+- Legacy vault compatibility if you have existing ` ```ad- ` style admonitions
+- Additional styling features not available in native callouts
+
+See the Admonition note in the vault for a detailed comparison between the plugin and native callouts.
+
+<details>
+<summary><strong>5. Admonition Installation (Optional)</strong></summary>
+
+#### Admonition Installation
+
+1. Search for "Admonition" in the community plugins browser and select the plugin by Jeremy Valentine
+
+![](/img/admonition-01.png)
+
+2. Click the "Install" button
+
+![](/img/admonition-02.png)
+
+3. After installation, click the "Enable" button
+
+![](/img/admonition-03.png)
+
+#### Admonition Configuration
+
+1. Click the "Options" button
+
+2. Toggle the "Add Copy Button" option to on for convenience
+
+</details>
+
 ## Verification Checklist
 
-* [ ] All 5 plugins enabled in Community plugins settings
+* [ ] All 4 required plugins enabled in Community plugins settings
 * [ ] Template files present in the `04 - Templates` directory
 * [ ] Git status visible in Obsidian status bar (if using Git)
 * [ ] Emoji toolbar responds to hotkey
 * [ ] New notes auto-apply templates when created in structured folders
+* [ ] Admonition plugin installed (optional)
 
 ## Getting Started
 

--- a/TODO.md
+++ b/TODO.md
@@ -30,12 +30,6 @@
     - [ ] Automatically generated/edited .gitignore
     - [ ] Update Obsidian Git note
 
-- [ ] Deprovision the Admonitions community plugin
- - [ ] Remove from README/installation scripts
- - [ ] Replace code blocks with callouts
- - [ ] Modify notes
- - [ ] Create a note on how to use Obsidian's admonition callouts
-
 - [ ] Installation instructions
   - [X] README
   - [x] Getting Started
@@ -47,6 +41,13 @@
 - [ ] Personal/unfinished ideas directory
   - [ ] Update installation scripts/instructions
   - [ ] Update vault structure notes
+
+- [ ] Improved code creation workflow
+  - [ ] Title character validation includes all invalid tag characters
+  - [ ] Title character validation includes all link-breaking characters
+  - [ ] Prompt for aliases
+  - [ ] Templater support for personal/unfinished ideas directory
+  - [ ] Primary/secondary category templates with pre-built collapsible Dataview queries
 
 ### Low Priority (Cleanup/Polish)
 
@@ -64,3 +65,9 @@
   - [ ] Vulnerability
 
 ## Done ✓
+
+- [x] Deprovision the Admonitions community plugin
+ - [x] Update README
+ - [x] Replace code blocks with callouts
+ - [x] Modify notes
+ - [x] Create a note on how to use Obsidian's admonition callouts


### PR DESCRIPTION
Removes Admonition from required plugins and reclassifies it as optional. Obsidian has natively supported callout boxes since v0.14.0 (March 2022), eliminating the need for this plugin in most cases.

Changes:
- **README.md**: Moved Admonition to "Optional Plugins" section
- **Installation**: Reduced required plugins from 5 to 4 (Obsidian Git, Templater, Dataview, Emoji Toolbar)
- **Documentation**: Created comprehensive _Obsidian - Callouts_ guide for native callout syntax
- **Content Notes**: Updated _Admonition_, _Obsidian - Getting Started_, and _Obsidian - Plugins_ notes to reflect new status
- **Code Blocks**: Replaced all preexisting Admonition code blocks with appropriately styled callouts

Benefits of native callouts:
- No installation required
- Better performance (native vs. plugin overhead)
- Future-proof (maintained by core Obsidian team)
- Simplified onboarding for new users
- Feature parity: collapsible blocks, custom titles, full Markdown support

When Admonition is still useful (optional):
- Legacy vault compatibility with ` ```ad-type ` syntax
- Advanced RGB color customization
- Custom callout types via plugin UI